### PR TITLE
add NXmpes_arpes subdef

### DIFF
--- a/pynxtools_mpes/reader.py
+++ b/pynxtools_mpes/reader.py
@@ -350,6 +350,12 @@ class MPESReader(BaseReader):
                                 f"Skipping the entry.",
                             )
 
+                # after filling, resolve links again:
+                if isinstance(template[key], str) and template[key].startswith(
+                    "@link:"
+                ):
+                    template[key] = {"link": template[key][6:]}
+
             else:
                 # Fills in the fixed metadata
                 template[key] = value

--- a/pynxtools_mpes/reader.py
+++ b/pynxtools_mpes/reader.py
@@ -287,7 +287,7 @@ class MPESReader(BaseReader):
     # pylint: disable=too-few-public-methods
 
     # Whitelist for the NXDLs that the reader supports and can process
-    supported_nxdls = ["NXmpes"]
+    supported_nxdls = ["NXmpes", "NXmpes_arpes"]
 
     def read(  # pylint: disable=too-many-branches
         self,

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -34,19 +34,16 @@ def test_example_data():
         str(data_dir / "xarray_saved_small_calibration.h5"),
     )
 
-    for supported_nxdl in reader.supported_nxdls:
-        nxdl_file = os.path.join(
-            def_dir, "contributed_definitions", f"{supported_nxdl}.nxdl.xml"
-        )
+    nxdl_file = os.path.join(def_dir, "contributed_definitions", "NXmpes.nxdl.xml")
 
-        root = ET.parse(nxdl_file).getroot()
-        template = Template()
-        generate_template_from_nxdl(root, template)
+    root = ET.parse(nxdl_file).getroot()
+    template = Template()
+    generate_template_from_nxdl(root, template)
 
-        read_data = reader().read(template=Template(template), file_paths=input_files)
+    read_data = reader().read(template=Template(template), file_paths=input_files)
 
-        assert isinstance(read_data, Template)
-        assert validate_data_dict(template, read_data, root)
+    assert isinstance(read_data, Template)
+    assert validate_data_dict(template, read_data, root)
 
 
 def test_mpes_writing(tmp_path):


### PR DESCRIPTION
This adds the NXmpes_arpes as allowed definition. It does, however, break the test, as our test data do not cover the requirements of this appdef. 
@domna Any suggestions how to fix that?

It also adds a section to split @link values written to the template by the reader from the xarray data or attributes, allowing to dynamically create links with a static config file.