### PR TITLE
New CI/CD strategy

### DIFF
--- a/.github/workflows/compatibility_with_pynxtools_release.yaml
+++ b/.github/workflows/compatibility_with_pynxtools_release.yaml
@@ -1,0 +1,41 @@
+name: Compatibility with pynxtools
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pynx_compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pynxtools_version: ["latest"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Install uv and set the python version to 3.12
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - name: Install pynxtools-mpes
+        run: |
+          uv pip install ".[dev]"
+      - name: Install nomad
+        run: |
+          uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
+      - name: Install pynxtools release version ${{ matrix.pynxtools_version }}
+        run: |
+          if [ "${{ matrix.pynxtools_version }}" == "latest" ]; then
+            uv pip install pynxtools
+          else
+           uv pip install pynxtools==${{ matrix.pynxtools_version }}
+          fi
+      - name: Run tests
+        run: |
+          pytest tests/.

--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main  # Triggers deployment on push to the main branch
 
-env:
-  UV_SYSTEM_PYTHON: true
-
 permissions:
    contents: write
 jobs:
@@ -23,10 +20,10 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version to 3.12
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.x'
+          python-version: 3.12
 
       - name: Cache mkdocs-material enviroment
         uses: actions/cache@v3
@@ -38,7 +35,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
           uv pip install ".[docs]"
 
       - name: Build and Deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install nomad
       run: |
         uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
-    - name: Install pynxtools-xps
+    - name: Install pynxtools-mpes
       run: |
         uv pip install ".[dev]"
         uv pip install coverage coveralls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,31 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Install uv and use the python version 3.12
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: "3.x"
-    - name: Install dependencies
+        python-version: 3.12
+
+    # Final pytest with latest pynxtools release
+    - name: Install nomad
       run: |
-        python -m pip install --upgrade pip
+        uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
+    - name: Install pynxtools-xps
+      run: |
+        uv pip install ".[dev]"
+        uv pip install coverage coveralls
+    - name: Install latest pynxtools release
+      run: |
+        uv pip install pynxtools
+    - name: Run tests
+      run: |
+        pytest tests/.
+
+    # Build
+    - name: Install build dependencies
+      run: |
         git reset --hard HEAD
-        pip install build
+        uv pip install build
     - name: Build package
       run: python -m build
     - name: Publish package distributions to PyPI

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,18 +2,15 @@ name: linting
 
 on: [push]
 
-env:
-  UV_SYSTEM_PYTHON: true
-
 jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version to 3.12
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.10"
+          python-version: 3.12
       - name: Install package and dev dependencies
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: pytest
 
 on:
@@ -9,34 +6,30 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  UV_SYSTEM_PYTHON: true
-
 jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version to ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python_version }}
-      - name: Install dependencies
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv pip install coverage coveralls
+          python-version: ${{ matrix.python-version }}
       - name: Install nomad
-        if: "${{ matrix.python_version != '3.8' && matrix.python_version != '3.9'}}"
+        if: "${{ matrix.python-version != '3.8' && matrix.python-version != '3.9'}}"
         run: |
           uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
       - name: Install package
         run: |
-          uv pip install -e ".[dev]"
+          uv pip install ".[dev]"
+      - name: Install pynxtools master branch
+        run: |
+          uv pip install pynxtools@git+https://github.com/FAIRmat-NFDI/pynxtools@master
       - name: Test with pytest
         run: |
           coverage run -m pytest -sv --show-capture=no tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,22 +20,23 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install package and test dependencies
+        run: |
+          uv pip install ".[dev]"
+          uv pip install coverage coveralls
+      - name: Install pynxtools master branch
+        run: |
+          uv pip install pynxtools@git+https://github.com/FAIRmat-NFDI/pynxtools@master
       - name: Install nomad
         if: "${{ matrix.python-version != '3.8' && matrix.python-version != '3.9'}}"
         run: |
           uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
-      - name: Install package
-        run: |
-          uv pip install ".[dev]"
-      - name: Install pynxtools master branch
-        run: |
-          uv pip install pynxtools@git+https://github.com/FAIRmat-NFDI/pynxtools@master
       - name: Test with pytest
         run: |
           coverage run -m pytest -sv --show-capture=no tests
       - name: Submit to coveralls
         continue-on-error: true
-        if: "${{ matrix.python_version == '3.12'}}"
+        if: "${{ matrix.python-version == '3.12'}}"
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package and test dependencies
         run: |
-          uv pip install ".[dev]"
+          uv pip install -e ".[dev]"
           uv pip install coverage coveralls
       - name: Install pynxtools master branch
         run: |


### PR DESCRIPTION
- Use `setup-uv` everywhere

New test strategy:
- **pytest.yaml** 
  -> purpose: test against pynxtools master
  -> install plugin from branch as .dev + pynxtools master + nomad develop
- **publish.yaml** 
  -> install plugin as .dev + pynxtools latest release  + nomad release 
   -> run pytest against latest pynxtools release _before_ new release of `pynxtools-mpes`
- **compatibility_with_pynxtools_release.yaml**
  -> purpose: (optional) test against pynxtools release directly within a given PR
  -> install plugin from branch as .dev + pynxtools latest release  + nomad (develop)
  -> make this a test that CAN fail, but does not break the CI/CD -> I can do this is in the repo settings once this PR is merged