### PR TITLE
minor fix for `AXISNAME_indices`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: 'pynxtools-mpes: A pynxtools reader plugin for multidimensional photoemission spectroscopy (MPES) data'
-version: 0.2.3
+version: 0.2.4
 message:
   If you use this software, please cite it using the
   metadata from this file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "h5py>=3.6.0",
     "xarray>=0.20.2",
-    "pynxtools>=0.10.2",
+    "pynxtools>=0.10.7",
 ]
 
 [project.optional-dependencies]

--- a/tests/data/config_file.json
+++ b/tests/data/config_file.json
@@ -402,7 +402,7 @@
   },
   "/ENTRY/DATA[data]": {
     "@axes": "@data:dims",
-    "AXISNAME_indices[@*_indices]": "@data:*.index",
+    "@AXISNAME_indices[@*_indices]": "@data:*.index",
     "@signal": "data",
     "data": "@data:data",
     "data/@units": "counts",


### PR DESCRIPTION
Concept names for attributes must now be written with a starting `@` as well. First seen with https://github.com/FAIRmat-NFDI/pynxtools/pull/638