### PR TITLE
remove unneeded ignore_sections_all_tests from reader test

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -30,7 +30,7 @@ NXDLS = ["NXmpes"]  # READER_CLASS.supported_nxdls
 
 # Define lines/sections to be ignored in _all_ test cases
 ignore_lines_all_tests: list = []
-ignore_sections_all_tests: dict = {"ATTRS (//@creator_version)": ["DEBUG - value:"]}
+ignore_sections_all_tests: dict = {}
 
 data_dir_path = Path(__file__).parent / "data"
 


### PR DESCRIPTION
Not needed anymore because `pynx read` output has changed and the `creator_version` is filtered out automatically.